### PR TITLE
on release, create or update v1 branch

### DIFF
--- a/tag-release.sh
+++ b/tag-release.sh
@@ -14,3 +14,18 @@ fi
 NEW_RELEASE=$(./bin/autotag)
 git push --tags
 gh release create "v${NEW_RELEASE}" -t "v${NEW_RELEASE}" --generate-notes
+
+# Extract the major version number
+MAJOR_VERSION=$(echo "${NEW_RELEASE}" | cut -d'.' -f1)
+
+echo "Major version: ${MAJOR_VERSION}"
+
+MAJOR_VERSION_BRANCH="v${MAJOR_VERSION}"
+if git show-ref --verify --quiet refs/heads/action-path; then
+  git checkout -b "${MAJOR_VERSION_BRANCH}"
+else
+  git checkout "${MAJOR_VERSION_BRANCH}"
+fi
+
+git merge --ff-only main
+git push origin "${MAJOR_VERSION_BRANCH}"

--- a/tag-release.sh
+++ b/tag-release.sh
@@ -7,7 +7,6 @@ curl -sL https://git.io/autotag-install | sh --
 git fetch --tags --unshallow --prune
 
 if [ $(git rev-parse --abbrev-ref HEAD) != "main" ]; then
-  # ensure a local 'main' branch exists at 'refs/heads/main'
   git branch --track main origin/main
 fi
 

--- a/tag-release.sh
+++ b/tag-release.sh
@@ -20,11 +20,11 @@ MAJOR_VERSION=$(echo "${NEW_RELEASE}" | cut -d'.' -f1)
 echo "Major version: ${MAJOR_VERSION}"
 
 MAJOR_VERSION_BRANCH="v${MAJOR_VERSION}"
-if git show-ref --verify --quiet refs/heads/action-path; then
+if git show-ref --verify --quiet "refs/heads/${MAJOR_VERSION_BRANCH}"; then
   git checkout -b "${MAJOR_VERSION_BRANCH}"
 else
   git checkout "${MAJOR_VERSION_BRANCH}"
+  git merge --ff-only main
 fi
 
-git merge --ff-only main
 git push origin "${MAJOR_VERSION_BRANCH}"


### PR DESCRIPTION
Allow actions to point to v1 rather than a specific release