### PR TITLE
Allow missing spaces if followed by a newline.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Contributing
+
+## Releases
+New releases are tagged and released automatically on merge to main with [autotag](https://github.com/pantheon-systems/autotag) and the `gh` CLI tool. See [Autotag's README](https://github.com/pantheon-systems/autotag#scheme-autotag-default) for details of how to annotate commit messages to denote major, minor, or patch version bumps.
+
+### Releasing to GitHub Action Marketplace
+The release automation creates the tag and release, but `gh` cannot actually publish to the marketplace. To update the version available in the GitHub Marketplace, click the edit buttion on the latest release on the ["Release" page](https://github.com/pantheon-systems/validate-readme-spacing/releases) then on the edit page, check "Publish this Action to the GitHub Marketplace" and then click _Update Release_.
+
+## Tests
+
+Any .md file in `fixtures/` that begins with `good` or `bad` is tested for successful or unsuccessful validation respectively.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 lint:
-	shellcheck ./check-readme-newlines.sh
+	shellcheck ./*.sh
 
 test:
 	./test.sh

--- a/check-readme-newlines.sh
+++ b/check-readme-newlines.sh
@@ -37,7 +37,7 @@ while IFS= read -r line; do
     
 
     if [[ "${MAYBE_INVALID_LINE}" != "" ]]; then
-        echo "'$MAYBE_INVALID_LINE' is invalid"
+        echo "This line is missing its trailing spaces: '$MAYBE_INVALID_LINE'"
         INVALID_LINE_FOUND=1
     fi
     MAYBE_INVALID_LINE=""

--- a/check-readme-newlines.sh
+++ b/check-readme-newlines.sh
@@ -64,6 +64,7 @@ while IFS= read -r line; do
         continue
     fi
 
+    # This may be invalid, but if followed by a blank line, will be deemed acceptable.
     MAYBE_INVALID_LINE="${line}"
 done < "$file"
 

--- a/fixtures/bad-single-space.md
+++ b/fixtures/bad-single-space.md
@@ -1,0 +1,21 @@
+# Rossums Universal Robots
+Contributors: [pwtyler](https://profiles.wordpress.org/pwtyler)  
+Donate link: https://example.com/  
+Tags: comments, spam  
+Requires at least: 4.5  
+Tested up to: 6.2.1  
+Requires PHP: 5.6  
+Stable tag: 0.0.1 
+License: GPLv2 or later  
+License URI: https://www.gnu.org/licenses/gpl-2.0.html  
+
+See the robots hard at work: they are good at it.
+
+## Usage
+Install the plugin and use it.
+Foo: Bar
+
+## Changelog
+
+### 0.1.0 (6 June 2023)
+* Initial Release 

--- a/fixtures/good-last-line-newlines.md
+++ b/fixtures/good-last-line-newlines.md
@@ -1,0 +1,21 @@
+# Rossums Universal Robots
+Contributors: [pwtyler](https://profiles.wordpress.org/pwtyler)  
+Donate link: https://example.com/  
+Tags: comments, spam  
+Requires at least: 4.5  
+Tested up to: 6.2.1  
+Requires PHP: 5.6  
+Stable tag: 0.0.1  
+License: GPLv2 or later  
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+
+See the robots hard at work: they are good at it.
+
+## Usage
+Install the plugin and use it.
+* Step One: Install it.
+* Step Two: Profit
+## Changelog
+
+### 0.1.0 (6 June 2023)
+* Initial Release

--- a/fixtures/good-middle-line-newlines.md
+++ b/fixtures/good-middle-line-newlines.md
@@ -1,0 +1,22 @@
+# Rossums Universal Robots
+Contributors: [pwtyler](https://profiles.wordpress.org/pwtyler)  
+Donate link: https://example.com/  
+Tags: comments, spam  
+Requires at least: 4.5  
+Tested up to: 6.2.1  
+Requires PHP: 5.6
+
+Stable tag: 0.0.1  
+License: GPLv2 or later  
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+
+See the robots hard at work: they are good at it.
+
+## Usage
+Install the plugin and use it.
+* Step One: Install it.
+* Step Two: Profit
+## Changelog
+
+### 0.1.0 (6 June 2023)
+* Initial Release

--- a/tag-release.sh
+++ b/tag-release.sh
@@ -6,7 +6,7 @@ curl -sL https://git.io/autotag-install | sh --
 # fetch all tags and history:
 git fetch --tags --unshallow --prune
 
-if [ $(git rev-parse --abbrev-ref HEAD) != "main" ]; then
+if [ "$(git rev-parse --abbrev-ref HEAD)" != "main" ]; then
   git branch --track main origin/main
 fi
 

--- a/test.sh
+++ b/test.sh
@@ -1,20 +1,31 @@
 #!/bin/bash
 set -eou pipefail
 
+function main() {
+	for file in fixtures/*; do
+		if [[ -f "$file" ]]; then
+			local TEST_CASE
+			TEST_CASE=$(basename "$file")
+			test_fixture "fixtures/$TEST_CASE"
+			echo
+		fi
+	done
+}
+
 function test_fixture() {
 	local FIXTURE_FILE="${1-}"
 	echo "➡️ Running checks on ${FIXTURE_FILE}..."
 	local TEST_FILE="${FIXTURE_FILE#fixtures/}"
 
-	if [[ ${TEST_FILE} != *.md ]]; then
+	if [[ "${TEST_FILE}" != *.md ]]; then
 		echo "➖ ${FIXTURE_FILE} skipped, not a markdown file"
 		return
 	fi
-	if [[ ${TEST_FILE} == good* ]]; then
+	if [[ "${TEST_FILE}" == good* ]]; then
 		test_acceptable "${FIXTURE_FILE}"
 		return
 	fi
-	if [[ ${TEST_FILE} == bad* ]]; then
+	if [[ "${TEST_FILE}" == bad* ]]; then
 		test_unacceptable "${FIXTURE_FILE}"
 		return
 	fi
@@ -23,7 +34,7 @@ function test_fixture() {
 
 function test_acceptable() {
 	local FIXTURE_FILE="${1-}"
-	if bash check-readme-newlines.sh ${FIXTURE_FILE}; then
+	if bash check-readme-newlines.sh "${FIXTURE_FILE}"; then
 		echo "✅ Validated good README successfully!"
 	else
 		echo "🚫 Invalidated good README unsuccessfully. Did ${FIXTURE_FILE#fixtures/} file change? 😉"
@@ -32,20 +43,13 @@ function test_acceptable() {
 }
 
 function test_unacceptable() {
-	local fixture_file="${1-}"
-	if ! bash check-readme-newlines.sh ${fixture_file}; then
+	local FIXTURE_FILE="${1-}"
+	if ! bash check-readme-newlines.sh "${FIXTURE_FILE}"; then
 		echo "✅ Invalidated bad README successfully!"
 	else
-		echo "🚫 Validated bad README unsuccessfully. Did ${fixture_file#fixtures/} file change? 😉"
+		echo "🚫 Validated bad README unsuccessfully. Did ${FIXTURE_FILE#fixtures/} file change? 😉"
 		return 1
 	fi
 }
 
-for file in fixtures/*; do
-	if [[ -f "$file" ]]; then
-		TEST_CASE=$(basename "$file")
-		test_fixture "fixtures/$TEST_CASE"
-		echo
-	fi
-done
-
+main

--- a/test.sh
+++ b/test.sh
@@ -27,3 +27,10 @@ else
     echo "🚫 Invalidated good README unsuccessfully. Did the good-last-line-newlines.md file change? 😉"
     exit 1
 fi
+echo "Running checks on fixtures/good-middle-line-newlines.md..."
+if bash check-readme-newlines.sh fixtures/good-middle-line-newlines.md; then
+    echo "✅ Validated good README successfully!"
+else
+    echo "🚫 Invalidated good README unsuccessfully. Did the good-last-line-newlines.md file change? 😉"
+    exit 1
+fi

--- a/test.sh
+++ b/test.sh
@@ -18,3 +18,12 @@ else
     echo "🚫 Invalidated bad README unsuccessfully. Did the bad-single.md file change? 😉"
     exit 1
 fi
+
+echo "Validate a double newline is acceptable"
+echo "Running checks on fixtures/good-last-line-newlines.md..."
+if bash check-readme-newlines.sh fixtures/good-last-line-newlines.md; then
+    echo "✅ Validated good README successfully!"
+else
+    echo "🚫 Invalidated good README unsuccessfully. Did the good-last-line-newlines.md file change? 😉"
+    exit 1
+fi


### PR DESCRIPTION
Discovered in https://github.com/pantheon-systems/pantheon-hud/pull/126 that the final line should be valid as it is followed by a second newline, but linter errors it.

Also refactored tests and added CONTRIBUTING.md