### PR TITLE
chore: add dependabot github-actions grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds Dependabot configuration for this repo, which currently has none.

This repo is a shell-script GitHub Action with no composer/npm/go manifest, so only the `github-actions` ecosystem is configured. Updates to actions referenced in workflows are grouped into a single PR per run (via a wildcard pattern group) rather than one PR per action, since actions are tag-versioned rather than strict semver.

Matches the existing github-actions grouping pattern used in pantheon-hud, wordpress-internal, and phpcompatibility-action.